### PR TITLE
Support fenced code blocks in Jekyll collection documents

### DIFF
--- a/lib/octopress-codefence.rb
+++ b/lib/octopress-codefence.rb
@@ -16,6 +16,12 @@ module Octopress
       end
     end
 
+    class DocumentHook < Hooks::Document
+      def pre_render(document)
+        document.content = Codefence::Highlighter.new(document.content).render
+      end
+    end
+
     class Highlighter
       AllOptions = /([^\s]+)\s+(.+?)\s+(https?:\/\/\S+|\/\S+)\s*(.+)?/i
       LangCaption = /([^\s]+)\s*(.+)?/i


### PR DESCRIPTION
This allows fenced code blocks to be used in [Jekyll collection documents](http://jekyllrb.com/docs/collections/).

This closes #6.