### PR TITLE
Fix Jekyll Deprecation Warning

### DIFF
--- a/lib/octopress-codefence.rb
+++ b/lib/octopress-codefence.rb
@@ -5,7 +5,7 @@ module Octopress
   module Codefence
     Jekyll::Hooks.register [:posts, :pages, :documents], :pre_render do |item, payload|
       if item.respond_to?(:ext)
-        ext = item.ext
+        ext = item.data['ext']
       else
         ext = nil
       end


### PR DESCRIPTION
This PR fixes a deprecation warning, using the latest versions of this gem (1.7.0) and jekyll (3.1.1).

Warning was: 

```
Deprecation: Document#ext is now a key in the #data hash.
                    Called by /usr/local/lib/ruby/gems/2.3.0/gems/octopress-codefence-1.7.0/lib/octopress-codefence.rb:8:in `block in <module:Codefence>'.
```
