### PR TITLE
Fix "jekyll build" RuntimeError

### DIFF
--- a/lib/octopress-codefence.rb
+++ b/lib/octopress-codefence.rb
@@ -5,7 +5,7 @@ module Octopress
   module Codefence
     Jekyll::Hooks.register [:posts, :pages, :documents], :pre_render do |item, payload|
       if item.respond_to?(:ext)
-        ext = item.ext
+        ext = item.data['ext']
       else
         ext = nil
       end

--- a/lib/octopress-codefence.rb
+++ b/lib/octopress-codefence.rb
@@ -17,7 +17,7 @@ module Octopress
       LangCaption = /([^\s]+)\s*(.+)?/i
 
       def initialize(input, ext=nil, aliases=nil)
-        @input   = input
+        @input   = input.dup
         @ext     = ext
         @aliases = aliases
       end


### PR DESCRIPTION
Fix a `jekyll build` RuntimeError, when using the latest version of this gem (1.7.0) and and jekyll (3.7.2).

    /srv/bundle/bundler/gems/codefence-1ff084fe35c8/lib/octopress-codefence.rb:26:in `encode!': can't modify frozen String (RuntimeError)
            from /srv/bundle/bundler/gems/codefence-1ff084fe35c8/lib/octopress-codefence.rb:26:in `render'
            from /srv/bundle/bundler/gems/codefence-1ff084fe35c8/lib/octopress-codefence.rb:12:in `block in <module:Codefence>'
            from /srv/bundle/gems/jekyll-3.7.2/lib/jekyll/hooks.rb:103:in `block in trigger'
    ...

Extends off of #14.